### PR TITLE
Add rain delay and duration per sprinkler set

### DIFF
--- a/Hubitat/Simple Sprinklers - Child - HE.groovy
+++ b/Hubitat/Simple Sprinklers - Child - HE.groovy
@@ -189,12 +189,10 @@ def updated() {
     initialize()
 }
 
-
 def startHandler(evt){
     // The switch to turn on the sprinklers was enabled
     
     evt.value == "on" ? beginSprinklerProcess() : null
-
 }
 
 def stopHandler(evt){
@@ -203,8 +201,6 @@ def stopHandler(evt){
         state.finishedRunning = true
         endSprinkler()
     }
-
-
 }
 
 def allOff(){
@@ -217,8 +213,6 @@ def allOff(){
             this."setSprinkler${i}"('off')
         } else { break }
     }
-    
-
 }
 
 def startSprinkler(){

--- a/Hubitat/Simple Sprinklers - Child - HE.groovy
+++ b/Hubitat/Simple Sprinklers - Child - HE.groovy
@@ -44,73 +44,85 @@ def childSetup() {
             paragraph "<hr><h2>Select Sprinklers</h2>"
             input "sprinkler1", "capability.switch", title: "Turn on these switches...", multiple:true, required: false
             input "sprinkler1valve", "capability.valve", title: "Open these valves...", multiple:true, required: false
-            
-            paragraph "<h2>For this many minutes...</h2>"
-            input "sprinklerDuration", "number", title: "Duration (minutes)", required: true, defaultValue: 30
+            input "sprinkler1Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30
             
             paragraph "<h2>Then, wait for this many minutes...</h2>"
             input "sprinklerPause", "number", title: "Duration (minutes)", required: true, defaultValue: 5
             
-            
             paragraph "<h2>After waiting, repeat for these sprinkler(s)</h2>"
             input "sprinkler2", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
             input "sprinkler2valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+            input "sprinkler2Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             
             if(settings.sprinkler2 || settings.sprinkler2valve){
                 input "sprinkler3", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler3valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler3Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler3 || settings.sprinkler3valve){
                 input "sprinkler4", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler4valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler4Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler4 || settings.sprinkler4valve){
                 input "sprinkler5", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler5valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler5Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler5 || settings.sprinkler5valve){
                 input "sprinkler6", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler6valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler6Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler6 || settings.sprinkler6valve){
                 input "sprinkler7", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler7valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler7Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler7 || settings.sprinkler7valve){
                 input "sprinkler8", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler8valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler8Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler8 || settings.sprinkler8valve){
                 input "sprinkler9", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler9valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler9Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler9 || settings.sprinkler9valve){
                 input "sprinkler10", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler10valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler10Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler10 || settings.sprinkler10valve){
                 input "sprinkler11", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler11valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler11Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler11 || settings.sprinkler11valve){
                 input "sprinkler12", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler12valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler12Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler12 || settings.sprinkler12valve){
                 input "sprinkler13", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler13valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler13Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler13 || settings.sprinkler13valve){
                 input "sprinkler14", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler14valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler14Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler14 || settings.sprinkler14valve){
                 input "sprinkler15", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler15valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler15Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
              if(settings.sprinkler15 || settings.sprinkler15valve){
                 input "sprinkler16", "capability.switch", title: "Turn on these switches...", multiple:true, required: false, submitOnChange: true
                 input "sprinkler16valve", "capability.valve", title: "Open these valves...", multiple:true, required: false, submitOnChange: true
+                input "sprinkler16Duration", "number", title: "For this many minutes...", required: true, defaultValue: 30, submitOnChange: true
             }
             
             paragraph "<hr><h2>Rain delay</h2>"
@@ -218,6 +230,7 @@ def allOff(){
 def startSprinkler(){
     // Start sprinkler
     
+    def sprinklerDuration = settings."sprinkler${state.currentSprinkler}Duration"
     logDebug "Starting sprinkler set ${state.currentSprinkler} for ${sprinklerDuration} minutes."
     
     this."setSprinkler${state.currentSprinkler}"('on')

--- a/Hubitat/Simple Sprinklers - Child - HE.groovy
+++ b/Hubitat/Simple Sprinklers - Child - HE.groovy
@@ -139,6 +139,9 @@ def childSetup() {
                     description: "Logs data for debugging. (Default: On)", defaultValue: true,
                     required: true, displayDuringSetup: true)
 
+            paragraph "<hr><h2>Pause</h2>"
+            input "pauseSchedule", "bool", title: "Pause schedule", description: "Pause the schedule", defaultValue: false, required: false, submitOnChange: true
+
             label title: "<h2>Enter a name for this setup (optional)</h2>", required: false  
         }
     }
@@ -179,6 +182,10 @@ def beginSprinklerProcess(){
     logDebug "Rain delay days: ${rainDelayDays}"
     if (rainDelayDays != null && rainDelayDays != 0){
         logDebug "Rain delay is active. Not running automation."
+        return
+    }
+    if (pauseSchedule){
+        logDebug "Schedule is paused. Not running automation."
         return
     }
     logDebug "Beginning scheduled sprinklers"


### PR DESCRIPTION
I added a couple of features that I find useful for the way I water my landscaping:

- **Rain delay variable** - The app will check a hub variable and only run the sprinklers if the variable is equal to 0. The intent is for the user to create a hub variable and a rule that decrements it each day at midnight. If the user needs to delay watering due to rain, they can set the variable to the number of days to delay watering. The Simple Sprinklers app won't run the sprinklers until the variable has been decremented down to 0 by the rule. The variable can also be set to -1 if the user wants to enable a permanent rain delay. The sprinklers will not run until the user sets the variable back to 0.
- **Duration per sprinkler set** - I find it useful to be able to water all of my shrubs using a single app, but my shrubs are divided between two valves. I like to give some of the shrubs more water than the others, so I added the ability to specify a duration per sprinkler set.

Thanks for creating this app!